### PR TITLE
Set up pre-commit for black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    -   id: black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ Please create a new issue on [GitHub](https://github.com/climate-processes/tobac
 * If it is a larger change or an newly added feature or workflow, please place an example of use in the [tobac-tutorials](https://github.com/climate-processes/tobac-tutorials) repository or adapt the existing examples there.
 * If necessary add a folder or modify a file.
 * The code should be PEP 8 compliant, as this facilitates our collaboration. Please use the latest version of [black](https://black.readthedocs.io/en/stable/) to format your code. When you submit a pull request, all files are checked for formatting.
+* The tobac repository is set up with pre-commit hooks to automatically format your code when commiting changes. Please run the command "pre-commit install" in the root directory of tobac to set up pre-commit formatting.
 
-We hope that we can respond within two weeks.
+We aim to respond to all new issues/pull requests as soon as possible, however at times this is not possible due to work commitments.
 
 ### Numpydoc Example <a name='docstringExample'>
 ```python

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -4,9 +4,10 @@ scipy
 scikit-image
 pandas
 pytables
-matplotlib 
+matplotlib
 iris
-cf-units 
-xarray 
+cf-units
+xarray
 cartopy
 trackpy
+pre-commit


### PR DESCRIPTION
Fulfills issue #82  

Also adds pre-commit to required packages for conda install (from source only)