### PR TITLE
Remove setting backend to `agg` automatically

### DIFF
--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -1,6 +1,5 @@
 import matplotlib as mpl
-
-import matplotlib.pyplot as plt
+import warnings
 import logging
 from .analysis import lifetime_histogram
 from .analysis import histogram_cellwise, histogram_featurewise
@@ -24,10 +23,15 @@ def plot_tracks_mask_field_loop(
     margin_top=0.05,
     **kwargs
 ):
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
     import cartopy.crs as ccrs
     import os
     from iris import Constraint
-
+    
     os.makedirs(plot_dir, exist_ok=True)
     time = mask.coord("time")
     if name is None:
@@ -97,6 +101,8 @@ def plot_tracks_mask_field(
     rasterized=True,
     linewidth_contour=1,
 ):
+    import matplotlib.pyplot as plt    
+
     import cartopy
     from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
     import iris.plot as iplt
@@ -259,6 +265,12 @@ def plot_tracks_mask_field(
 def animation_mask_field(
     track, features, field, mask, interval=500, figsize=(10, 10), **kwargs
 ):
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     import cartopy.crs as ccrs
     import matplotlib.pyplot as plt
     import matplotlib.animation
@@ -309,6 +321,13 @@ def plot_mask_cell_track_follow(
     Input:
     Output:
     """
+
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     from iris import Constraint
     from numpy import unique
     import os
@@ -432,6 +451,10 @@ def plot_mask_cell_individual_follow(
     Input:
     Output:
     """
+
+    import matplotlib.pyplot as plt    
+
+
     import numpy as np
     from .utils import mask_cell_surface
     from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -623,6 +646,12 @@ def plot_mask_cell_track_static(
     Input:
     Output:
     """
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     from iris import Constraint
     from numpy import unique
     import os
@@ -774,6 +803,7 @@ def plot_mask_cell_individual_static(
     Input:
     Output:
     """
+    import matplotlib.pyplot as plt    
 
     import numpy as np
     from .utils import mask_features, mask_features_surface
@@ -975,6 +1005,12 @@ def plot_mask_cell_track_2D3Dstatic(
     Input:
     Output:
     """
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     from iris import Constraint
     from numpy import unique
     import os
@@ -1141,6 +1177,12 @@ def plot_mask_cell_track_3Dstatic(
     Input:
     Output:
     """
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     from iris import Constraint
     from numpy import unique
     import os
@@ -1301,6 +1343,7 @@ def plot_mask_cell_individual_3Dstatic(
     Input:
     Output:
     """
+    import matplotlib.pyplot as plt    
 
     import numpy as np
     from .utils import mask_features, mask_features_surface
@@ -1492,6 +1535,13 @@ def plot_mask_cell_track_static_timeseries(
     Input:
     Output:
     """
+
+    mpl_backend = mpl.get_backend()
+    if mpl_backend != 'agg':
+        warnings.warn("When using tobac plotting functions that render a figure, you may need "
+                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
+    import matplotlib.pyplot as plt    
+
     from iris import Constraint
     from numpy import unique
     import os

--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -24,14 +24,16 @@ def plot_tracks_mask_field_loop(
     **kwargs
 ):
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
     import cartopy.crs as ccrs
     import os
     from iris import Constraint
-    
+
     os.makedirs(plot_dir, exist_ok=True)
     time = mask.coord("time")
     if name is None:
@@ -101,7 +103,7 @@ def plot_tracks_mask_field(
     rasterized=True,
     linewidth_contour=1,
 ):
-    import matplotlib.pyplot as plt    
+    import matplotlib.pyplot as plt
 
     import cartopy
     from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
@@ -266,10 +268,12 @@ def animation_mask_field(
     track, features, field, mask, interval=500, figsize=(10, 10), **kwargs
 ):
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     import cartopy.crs as ccrs
     import matplotlib.pyplot as plt
@@ -323,10 +327,12 @@ def plot_mask_cell_track_follow(
     """
 
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     from iris import Constraint
     from numpy import unique
@@ -452,8 +458,7 @@ def plot_mask_cell_individual_follow(
     Output:
     """
 
-    import matplotlib.pyplot as plt    
-
+    import matplotlib.pyplot as plt
 
     import numpy as np
     from .utils import mask_cell_surface
@@ -647,10 +652,12 @@ def plot_mask_cell_track_static(
     Output:
     """
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     from iris import Constraint
     from numpy import unique
@@ -803,7 +810,7 @@ def plot_mask_cell_individual_static(
     Input:
     Output:
     """
-    import matplotlib.pyplot as plt    
+    import matplotlib.pyplot as plt
 
     import numpy as np
     from .utils import mask_features, mask_features_surface
@@ -1006,10 +1013,12 @@ def plot_mask_cell_track_2D3Dstatic(
     Output:
     """
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     from iris import Constraint
     from numpy import unique
@@ -1178,10 +1187,12 @@ def plot_mask_cell_track_3Dstatic(
     Output:
     """
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     from iris import Constraint
     from numpy import unique
@@ -1343,7 +1354,7 @@ def plot_mask_cell_individual_3Dstatic(
     Input:
     Output:
     """
-    import matplotlib.pyplot as plt    
+    import matplotlib.pyplot as plt
 
     import numpy as np
     from .utils import mask_features, mask_features_surface
@@ -1537,10 +1548,12 @@ def plot_mask_cell_track_static_timeseries(
     """
 
     mpl_backend = mpl.get_backend()
-    if mpl_backend != 'agg':
-        warnings.warn("When using tobac plotting functions that render a figure, you may need "
-                    "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg').")
-    import matplotlib.pyplot as plt    
+    if mpl_backend != "agg":
+        warnings.warn(
+            "When using tobac plotting functions that render a figure, you may need "
+            "to set the Matplotlib backend to 'agg' by `matplotlib.use('agg')."
+        )
+    import matplotlib.pyplot as plt
 
     from iris import Constraint
     from numpy import unique

--- a/tobac/plotting.py
+++ b/tobac/plotting.py
@@ -1,6 +1,5 @@
 import matplotlib as mpl
 
-mpl.use("Agg")
 import matplotlib.pyplot as plt
 import logging
 from .analysis import lifetime_histogram


### PR DESCRIPTION
Resolves #95.

@w-k-jones I think there's a chance that this could potentially break some code. For example, if a user tries to run `tobac.plotting.plot_tracks_mask_field_loop` in a script without setting their own backend, it could break. We could resolve it by putting the matplotlib imports into each function and setting `mpl.use('agg')` there, but I still think we're better off having the users set their own backend as `agg` isn't appropriate for all cases. 