### PR TITLE
Parameter warnings

### DIFF
--- a/examples/Example_OLR_Tracking_model/Example_OLR_Tracking_model.ipynb
+++ b/examples/Example_OLR_Tracking_model/Example_OLR_Tracking_model.ipynb
@@ -165,7 +165,7 @@
     "parameters_features={}\n",
     "parameters_features['position_threshold']='weighted_diff'\n",
     "parameters_features['sigma_threshold']=0.5\n",
-    "parameters_features['min_num']=4\n",
+    "parameters_features['n_min_threshold']=4\n",
     "parameters_features['target']='minimum'\n",
     "parameters_features['threshold']=[250,225,200,175,150]"
    ]
@@ -409,7 +409,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -423,7 +423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/examples/Example_OLR_Tracking_satellite/Example_OLR_Tracking_satellite.ipynb
+++ b/examples/Example_OLR_Tracking_satellite/Example_OLR_Tracking_satellite.ipynb
@@ -296,7 +296,7 @@
     "parameters_features={}\n",
     "parameters_features['position_threshold']='weighted_diff'\n",
     "parameters_features['sigma_threshold']=0.5\n",
-    "parameters_features['min_num']=4\n",
+    "parameters_features['n_min_threshold']=4\n",
     "parameters_features['target']='minimum'\n",
     "parameters_features['threshold']=[250,225,200,175,150]"
    ]
@@ -538,7 +538,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -552,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/examples/Example_Precip_Tracking/Example_Precip_Tracking.ipynb
+++ b/examples/Example_Precip_Tracking/Example_Precip_Tracking.ipynb
@@ -324,7 +324,6 @@
     "parameters_features={}\n",
     "parameters_features['position_threshold']='weighted_diff'\n",
     "parameters_features['sigma_threshold']=0.5\n",
-    "parameters_features['min_num']=3\n",
     "parameters_features['min_distance']=0\n",
     "parameters_features['sigma_threshold']=1\n",
     "parameters_features['threshold']=[1,2,3,4,5,10,15] #mm/h\n",
@@ -438,8 +437,7 @@
     "parameters_linking['memory']=0\n",
     "parameters_linking['time_cell_min']=5*60\n",
     "parameters_linking['method_linking']='predict'\n",
-    "parameters_linking['v_max']=10\n",
-    "parameters_linking['d_min']=2000\n"
+    "parameters_linking['v_max']=10\n"
    ]
   },
   {
@@ -589,7 +587,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -603,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/examples/Example_Updraft_Tracking/Example_Updraft_Tracking.ipynb
+++ b/examples/Example_Updraft_Tracking/Example_Updraft_Tracking.ipynb
@@ -559,7 +559,6 @@
     "parameters_features={}\n",
     "parameters_features['position_threshold']='weighted_diff'\n",
     "parameters_features['sigma_threshold']=0.5\n",
-    "parameters_features['min_num']=3\n",
     "parameters_features['min_distance']=0\n",
     "parameters_features['sigma_threshold']=1\n",
     "parameters_features['threshold']=[3,5,10] #m/s\n",
@@ -658,8 +657,7 @@
     "parameters_linking['memory']=0\n",
     "parameters_linking['time_cell_min']=5*60\n",
     "parameters_linking['method_linking']='predict'\n",
-    "parameters_linking['v_max']=10\n",
-    "parameters_linking['d_min']=2000\n"
+    "parameters_linking['v_max']=10\n"
    ]
   },
   {
@@ -763,7 +761,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -777,7 +775,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 import pandas as pd
 from . import utils as tb_utils
-
+import warnings
 
 def feature_position(
     hdim1_indices,
@@ -205,6 +205,9 @@ def feature_detection_threshold(
     from skimage.morphology import binary_erosion
     from copy import deepcopy
 
+    if min_num !=0:
+        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
+
     # if looking for minima, set values above threshold to 0 and scale by data minimum:
     if target == "maximum":
         mask = 1 * (data_i >= threshold)
@@ -362,6 +365,9 @@ def feature_detection_multithreshold_timestep(
     """
     from scipy.ndimage.filters import gaussian_filter
 
+    if min_num !=0:
+        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
+
     track_data = data_i.core_data()
 
     track_data = gaussian_filter(
@@ -446,6 +452,9 @@ def feature_detection_multithreshold(
                    detected features
     """
     from .utils import add_coordinates
+
+    if min_num !=0:
+        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
 
     logging.debug("start feature detection based on thresholds")
 

--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -4,6 +4,7 @@ import pandas as pd
 from . import utils as tb_utils
 import warnings
 
+
 def feature_position(
     hdim1_indices,
     hdim2_indices,
@@ -205,8 +206,11 @@ def feature_detection_threshold(
     from skimage.morphology import binary_erosion
     from copy import deepcopy
 
-    if min_num !=0:
-        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
+    if min_num != 0:
+        warnings.warn(
+            "min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead",
+            FutureWarning,
+        )
 
     # if looking for minima, set values above threshold to 0 and scale by data minimum:
     if target == "maximum":
@@ -365,8 +369,11 @@ def feature_detection_multithreshold_timestep(
     """
     from scipy.ndimage.filters import gaussian_filter
 
-    if min_num !=0:
-        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
+    if min_num != 0:
+        warnings.warn(
+            "min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead",
+            FutureWarning,
+        )
 
     track_data = data_i.core_data()
 
@@ -453,8 +460,11 @@ def feature_detection_multithreshold(
     """
     from .utils import add_coordinates
 
-    if min_num !=0:
-        warnings.warn("min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead", FutureWarning)
+    if min_num != 0:
+        warnings.warn(
+            "min_num parameter has no effect and will be deprecated in a future version of tobac. Please use n_min_threshold instead",
+            FutureWarning,
+        )
 
     logging.debug("start feature detection based on thresholds")
 

--- a/tobac/tests/test_feature_detection.py
+++ b/tobac/tests/test_feature_detection.py
@@ -36,7 +36,7 @@ def test_feature_detection_multithreshold_timestep():
     )
     test_data_iris = testing.make_dataset_from_arr(test_data, data_type="iris")
     fd_output = feature_detection.feature_detection_multithreshold_timestep(
-        test_data_iris, 0, threshold=test_threshs, min_num=test_min_num
+        test_data_iris, 0, threshold=test_threshs, n_min_threshold=test_min_num
     )
 
     # Make sure we have only one feature

--- a/tobac/tests/test_sample_data.py
+++ b/tobac/tests/test_sample_data.py
@@ -59,7 +59,6 @@ def test_tracking_coord_order():
     parameters_features = {}
     parameters_features["position_threshold"] = "weighted_diff"
     parameters_features["sigma_threshold"] = 0.5
-    parameters_features["min_num"] = 3
     parameters_features["min_distance"] = 0
     parameters_features["sigma_threshold"] = 1
     parameters_features["threshold"] = [3, 5, 10]  # m/s
@@ -115,7 +114,6 @@ def test_tracking_coord_order():
     parameters_linking["time_cell_min"] = 5 * 60
     parameters_linking["method_linking"] = "predict"
     parameters_linking["v_max"] = 100
-    parameters_linking["d_min"] = 2000
 
     Track = linking_trackpy(Features, sample_data, dt=dt, dxy=dxy, **parameters_linking)
     Track_inv = linking_trackpy(
@@ -133,7 +131,6 @@ def test_tracking_3D():
     parameters_features = {}
     parameters_features["position_threshold"] = "weighted_diff"
     parameters_features["sigma_threshold"] = 0.5
-    parameters_features["min_num"] = 3
     parameters_features["min_distance"] = 0
     parameters_features["sigma_threshold"] = 1
     parameters_features["threshold"] = [3, 5, 10]  # m/s
@@ -188,7 +185,6 @@ def test_tracking_3D():
     parameters_linking["time_cell_min"] = 5 * 60
     parameters_linking["method_linking"] = "predict"
     parameters_linking["v_max"] = 100
-    parameters_linking["d_min"] = 2000
 
     Track = linking_trackpy(Features, sample_data, dt=dt, dxy=dxy, **parameters_linking)
     Track_inv = linking_trackpy(

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import warnings
 
+
 def linking_trackpy(
     features,
     field_in,
@@ -57,15 +58,22 @@ def linking_trackpy(
     # calculate search range based on timestep and grid spacing
     if d_max is not None:
         if v_max is not None:
-            raise ValueError("Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour")
+            raise ValueError(
+                "Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour"
+            )
         search_range = int(d_max / dxy)
 
     # calculate search range based on timestep and grid spacing
     if d_min is not None:
         if (v_max is not None) or (d_max is not None):
-            raise ValueError("Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour")
+            raise ValueError(
+                "Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour"
+            )
         search_range = int(d_min / dxy)
-        warnings.warn("d_min parameter will be deprecated in a future version of tobac. Please use d_max instead", FutureWarning)
+        warnings.warn(
+            "d_min parameter will be deprecated in a future version of tobac. Please use d_max instead",
+            FutureWarning,
+        )
 
     if time_cell_min:
         stubs = np.floor(time_cell_min / dt) + 1

--- a/tobac/tracking.py
+++ b/tobac/tracking.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import pandas as pd
-
+import warnings
 
 def linking_trackpy(
     features,
@@ -56,11 +56,16 @@ def linking_trackpy(
 
     # calculate search range based on timestep and grid spacing
     if d_max is not None:
+        if v_max is not None:
+            raise ValueError("Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour")
         search_range = int(d_max / dxy)
 
     # calculate search range based on timestep and grid spacing
     if d_min is not None:
-        search_range = max(search_range, int(d_min / dxy))
+        if (v_max is not None) or (d_max is not None):
+            raise ValueError("Multiple parameter inputs for v_max, d_max or d_min have been provided. Only use one of these parameters as they supercede each other leading to unexpected behaviour")
+        search_range = int(d_min / dxy)
+        warnings.warn("d_min parameter will be deprecated in a future version of tobac. Please use d_max instead", FutureWarning)
 
     if time_cell_min:
         stubs = np.floor(time_cell_min / dt) + 1


### PR DESCRIPTION
Issues #67 and #63 raised times in which duplicate or redundant parameters are used in feature detection and tracking. This PR adds future warnings for two parameters that are to be depreciated in future (min_num in feature detection and d_min in tracking) and adds an exception if multiple conflicting parameters are used. Example notebooks and tests have been updated to stop using depreciated parameters.