### PR TITLE
Fix depreciation warnings that we can fix

### DIFF
--- a/tobac/feature_detection.py
+++ b/tobac/feature_detection.py
@@ -360,7 +360,11 @@ def feature_detection_multithreshold_timestep(
     features_threshold:      pandas DataFrame
                              detected features for individual timestep
     """
-    from scipy.ndimage.filters import gaussian_filter
+    # Handle scipy depreciation gracefully
+    try:
+        from scipy.ndimage import gaussian_filter
+    except ImportError:
+        from scipy.ndimage.filters import gaussian_filter
 
     track_data = data_i.core_data()
 
@@ -388,7 +392,7 @@ def feature_detection_multithreshold_timestep(
             idx_start=idx_start,
         )
         if any([x is not None for x in features_threshold_i]):
-            features_thresholds = features_thresholds.append(features_threshold_i)
+            features_thresholds = pd.concat([features_thresholds, features_threshold_i])
 
         # For multiple threshold, and features found both in the current and previous step, remove "parent" features from Dataframe
         if i_threshold > 0 and not features_thresholds.empty and regions_old:

--- a/tobac/tests/test_testing.py
+++ b/tobac/tests/test_testing.py
@@ -7,7 +7,7 @@ from tobac.testing import generate_single_feature
 import tobac.testing as tbtest
 from collections import Counter
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import datetime
 
 

--- a/tobac/tests/test_tracking.py
+++ b/tobac/tests/test_tracking.py
@@ -5,7 +5,7 @@ import pytest
 import tobac.testing
 import tobac.tracking
 import copy
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 import numpy as np
 
 


### PR DESCRIPTION
Resolves #108 and #101. New warnings summary is below. Note that the warnings are either upstream in trackpy or iris-related, which I don't think we want to deal with. 

```
================================================== warnings summary ===================================================
tobac/tests/test_sample_data.py::test_sample_data
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1982: UserWarning: Collapsing a non-contiguous coordinate. Metadata may not be fully descriptive for 'time'.
    warnings.warn(msg.format(self.name()))

tobac/tests/test_sample_data.py::test_sample_data
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1982: UserWarning: Collapsing a non-contiguous coordinate. Metadata may not be fully descriptive for 'projection_y_coordinate'.
    warnings.warn(msg.format(self.name()))

tobac/tests/test_sample_data.py::test_sample_data
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1982: UserWarning: Collapsing a non-contiguous coordinate. Metadata may not be fully descriptive for 'projection_x_coordinate'.
    warnings.warn(msg.format(self.name()))

tobac/tests/test_sample_data.py::test_sample_data
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1976: UserWarning: Collapsing a multi-dimensional coordinate. Metadata may not be fully descriptive for 'latitude'.
    warnings.warn(msg.format(self.name()))

tobac/tests/test_sample_data.py::test_sample_data
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1976: UserWarning: Collapsing a multi-dimensional coordinate. Metadata may not be fully descriptive for 'longitude'.
    warnings.warn(msg.format(self.name()))

tobac/tests/test_sample_data.py::test_tracking_coord_order
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\trackpy\utils.py:201: DeprecationWarning: Importing clear_output from IPython.core.display is deprecated since IPython 7.14, please import from IPython display
    from IPython.core.display import clear_output

tobac/tests/test_sample_data.py::test_tracking_3D
  C:\Users\sfreeman\miniconda3\envs\tobac_dev\lib\site-packages\iris\coords.py:1982: UserWarning: Collapsing a non-contiguous coordinate. Metadata may not be fully descriptive for 'geopotential_height'.
    warnings.warn(msg.format(self.name()))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================ 9 passed, 7 warnings in 7.62s ============================================
```