### PR TITLE
updated get_spacings() to calculate dxy from 1D or 2D lat-lon values, independent of their dimension order 

### DIFF
--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -272,7 +272,7 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
                 # for 1D lats and lons  
                 lat_axis, lon_axis = -1, -1 
                 
-        # re-write to corresponding axis in 2D coords (needed if dimensions like time and )
+        # re-write to corresponding axis in 2D coords (needed if other dimensions precede lats and lons)
         if lon_axis > lat_axis:
             lat_axis, lon_axis  = -2,  -1 
         elif lon_axis < lat_axis:

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -259,8 +259,6 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
         # get min and max values of lats and lons
         lat1 = np.min(field_in.coord("latitude").points)
         lat2 = np.max(field_in.coord("latitude").points)
-        lon1 = np.min(field_in.coord("longitude").points)
-        lon2 = np.max(field_in.coord("longitude").points)
 
         # convert decimal degrees to radians
         lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -259,22 +259,21 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
         # get min and max values of lats and lons
         lat1 = np.min(field_in.coord("latitude").points)
         lat2 = np.max(field_in.coord("latitude").points)
-
         # convert decimal degrees to radians
-        lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+        lat1, lat2 = map(radians, [lat1, lat2])
 
-        # for 1D lats and lons  
+        # for 1D lats and lons :
         lat_axis = -1
         lon_axis = -1
-        # for 2D lats and lons 
-        if field_in.coord('latitude').points.ndim > 1:
-        # check if the data is structured in lons x lats or lats x lons
+        # for 2D lats and lons, check order 
+        if field_in.coord('latitude').points.ndim == 2:
             if field_in.coords()[1].name() != 'latitude':
                 lat_axis = -1
                 lon_axis = -2
             else:
                 lat_axis = -2
                 lon_axis = -1
+
         dlat = np.diff(field_in.coord("latitude").points, axis= lat_axis ).mean()
         dlon = np.diff(field_in.coord("longitude").points, axis = lon_axis).mean()
         # haversine formula 

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -264,9 +264,18 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
 
         # convert decimal degrees to radians
         lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
-        # haversine formula, note that value is divided by nr of grid cells along lat and lon
-        dlon = (lon2 - lon1) / np.shape(field_in.data)[1]
-        dlat = (lat2 - lat1) / np.shape(field_in.data)[2]
+
+        # for data that is structured lats x lons 
+        lat_axis = 0
+        lon_axis = 1
+        # check if the data is structured in lons x lats
+        if test.coords()[1].name() != 'latitude':
+            lat_axis = 1
+            lon_axis = 0
+        dlat = np.diff(test.coord("latitude").points, axis= lat_axis ).mean()
+        dlon = np.diff(test.coord("longitude").points, axis = lon_axis).mean()
+        # haversine formula 
+        dlat, dlon =  map(radians, [dlon, dlat])
         a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
         c = 2 * asin(sqrt(a))
         km = 6371 * c

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -265,15 +265,20 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
         # convert decimal degrees to radians
         lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
 
-        # for data that is structured lats x lons 
-        lat_axis = 0
-        lon_axis = 1
-        # check if the data is structured in lons x lats
-        if test.coords()[1].name() != 'latitude':
-            lat_axis = 1
-            lon_axis = 0
-        dlat = np.diff(test.coord("latitude").points, axis= lat_axis ).mean()
-        dlon = np.diff(test.coord("longitude").points, axis = lon_axis).mean()
+        # for 1D lats and lons  
+        lat_axis = -1
+        lon_axis = -1
+        # for 2D lats and lons 
+        if field_in.coord('latitude').points.ndim > 1:
+        # check if the data is structured in lons x lats or lats x lons
+            if field_in.coords()[1].name() != 'latitude':
+                lat_axis = -1
+                lon_axis = -2
+            else:
+                lat_axis = -2
+                lon_axis = -1
+        dlat = np.diff(field_in.coord("latitude").points, axis= lat_axis ).mean()
+        dlon = np.diff(field_in.coord("longitude").points, axis = lon_axis).mean()
         # haversine formula 
         dlat, dlon =  map(radians, [dlon, dlat])
         a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2

--- a/tobac/utils/general.py
+++ b/tobac/utils/general.py
@@ -262,18 +262,21 @@ def get_spacings(field_in, grid_spacing=None, time_spacing=None):
         # convert decimal degrees to radians
         lat1, lat2 = map(radians, [lat1, lat2])
 
-        # for 1D lats and lons :
-        lat_axis = -1
-        lon_axis = -1
-        # for 2D lats and lons, check order 
-        if field_in.coord('latitude').points.ndim == 2:
-            if field_in.coords()[1].name() != 'latitude':
-                lat_axis = -1
-                lon_axis = -2
+        # loop through coords to check dimension order 
+        for i, coord in enumerate(coord_names):
+            if coord == 'latitude' and field_in.coord(coord).ndim == 2:
+                lat_axis = i 
+            elif coord == 'longitude' and field_in.coord(coord).ndim == 2:
+                lon_axis = i 
             else:
-                lat_axis = -2
-                lon_axis = -1
-
+                # for 1D lats and lons  
+                lat_axis, lon_axis = -1, -1 
+                
+        # re-write to corresponding axis in 2D coords (needed if dimensions like time and )
+        if lon_axis > lat_axis:
+            lat_axis, lon_axis  = -2,  -1 
+        elif lon_axis < lat_axis:
+            lat_axis, lon_axis = -1 , -2
         dlat = np.diff(field_in.coord("latitude").points, axis= lat_axis ).mean()
         dlon = np.diff(field_in.coord("longitude").points, axis = lon_axis).mean()
         # haversine formula 


### PR DESCRIPTION
I updated `get_spacings()` in `utils/general.py` because previously this function assumed that for datasets with lon-lat coordinates, these were two-dimensional with 'lon' being the first dimension and 'lat' being the second dimension. I mistakenly introduced this with #65, and I think it is better to make the function more general so that it works for both 1D and 2D lat and lons and independent of their dimension order.
